### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ cython_debug/
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be added to the global gitignore or merged into this project gitignore.  For a PyCharm
 #  project, it is recommended to include the following files:
-  .idea/
+.idea
 #  *.iml
 #  *.ipr
 #  *.iws
@@ -245,3 +245,5 @@ logs/
 # Temporary files
 *.tmp
 *.temp
+
+modules/received_frame.jpg


### PR DESCRIPTION
### TL;DR

Improved ESP32 camera reliability and performance with optimized network transmission and configuration adjustments.

### What changed?

- Updated `.gitignore` to properly ignore the `.idea` directory and exclude `received_frame.jpg`
- Reduced camera clock frequency from 20MHz to 10MHz for better stability
- Decreased connection retry delay from 2000ms to 500ms for faster reconnection
- Implemented chunked image data transmission with 1KB chunks and small delays between chunks to prevent buffer overflows and improve WiFi stack stability

### How to test?

1. Flash the updated code to an ESP32 camera module
2. Verify the camera connects to the server more reliably
3. Check that image transmission is more stable, especially for larger frame sizes
4. Confirm the camera recovers faster when connection is lost

### Why make this change?

The ESP32 camera module was experiencing stability issues during image transmission, particularly with larger frame sizes. The high clock frequency and bulk data transmission were causing buffer overflows and connection failures. These changes optimize the camera configuration and implement a more network-friendly chunked transmission approach to improve reliability while maintaining performance.